### PR TITLE
Fix incorrect destination calculation for lanes past the first for datadev driver

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,6 +1,9 @@
 #
 # RELEASE_NOTES
 #
+R1.9.0  2025-07-22  Daniel Damiani
+    Fix how the dest is calculated from lane and vc for datadev driver
+
 R1.8.3  2025-06-03  Jeremy J. Lorelli
     Remove dependence on iocAdmin and autosave
 

--- a/pgpLib/src/Destination.cc
+++ b/pgpLib/src/Destination.cc
@@ -1,0 +1,82 @@
+#include "pds/pgp/Destination.hh"
+
+static const unsigned VC_MASK = 0x3;
+static const unsigned LANE_MASK = 0x7;
+static const unsigned PGP_DEST_OFFSET = 2;
+static const unsigned DATADEV_DEST_OFFSET = 8;
+
+static std::string LANE_NAMES[] = {
+  "Lane 0, ",
+  "Lane 1, ",
+  "Lane 2, ",
+  "Lane 3, ",
+  "Lane 4, ",
+  "Lane 5, ",
+  "Lane 6, ",
+  "Lane 7, ",
+  "--INVALID--"
+};
+static std::string VC_NAMES[] = {
+  "VC 0",
+  "VC 1",
+  "VC 2",
+  "VC 3",
+  "--INVALID--"
+};
+
+using namespace Pds::Pgp;
+
+Destination::Destination() :
+  _offset(PGP_DEST_OFFSET),
+  _dest(0)
+{}
+
+Destination::Destination(bool datadev, unsigned d) :
+  _offset(datadev ? DATADEV_DEST_OFFSET : PGP_DEST_OFFSET),
+  _dest(d)
+{}
+
+Destination::Destination(bool datadev, unsigned lane, unsigned vc) :
+  _offset(datadev ? DATADEV_DEST_OFFSET : PGP_DEST_OFFSET),
+  _dest(0)
+{
+  dest(lane, vc);
+}
+
+Destination::~Destination()
+{}
+
+void Destination::offset(unsigned o)
+{
+  _offset = o;
+}
+
+void Destination::dest(unsigned d)
+{
+  _dest = d;
+}
+
+void Destination::dest(unsigned lane, unsigned vc)
+{
+  _dest = (lane & LANE_MASK)<<_offset | (vc & VC_MASK);
+}
+
+unsigned Destination::dest() const
+{
+  return _dest;
+}
+
+unsigned Destination::lane() const
+{
+  return (_dest>>_offset) & LANE_MASK; 
+}
+
+unsigned Destination::vc() const
+{
+  return _dest & VC_MASK;
+}
+
+std::string Destination::name() const
+{
+  return LANE_NAMES[lane()] + VC_NAMES[vc()];
+}

--- a/pgpLib/src/Makefile
+++ b/pgpLib/src/Makefile
@@ -24,6 +24,7 @@ HTMLS_DIR	= .
 # Add any source files here
 # Note: No lib will be built if no sources are listed here
 LIBSRCS += drvPGP.cpp
+LIBSRCS += Destination.cc
 LIBSRCS += Pgp.cc
 LIBSRCS += SrpV3.cc
 LIBSRCS += Kcu1500Regs.cpp

--- a/pgpLib/src/Pgp.cc
+++ b/pgpLib/src/Pgp.cc
@@ -27,7 +27,7 @@ namespace Pds {
       _kcu(NULL)
     {
       char devName[128];
-      char err[128];
+      char err[256];
       sprintf(devName, "/dev/pgpcard_%u", mask & 0xf);
       if ( access( devName, F_OK ) != -1 ) {
         _type = G2;
@@ -43,7 +43,7 @@ namespace Pds {
       printf("Opening %s\n", devName);
       _fd = open( devName,  O_RDWR | O_NONBLOCK);
       if (_fd < 0) {
-        sprintf(err, "Pgp::Pgp() opening %s failed", devName);
+        snprintf(err, sizeof(err), "Pgp::Pgp() opening %s failed", devName);
         perror(err);
         throw "Can't open file";
       }

--- a/pgpLib/src/Pgp.cc
+++ b/pgpLib/src/Pgp.cc
@@ -70,15 +70,17 @@ namespace Pds {
         unsigned char maskBytes[DMA_MASK_SIZE];
         dmaInitMaskBytes(maskBytes);
         for(unsigned i=0; i<4; i++) {
-          if ((1<<i) & vcm)
-            pgpAddMaskBytes(maskBytes, _portOffset, i);
+          if ((1<<i) & vcm) {
+            Destination dest(usesDataDriver(), _portOffset, i);
+            dmaAddMaskBytes(maskBytes, dest.dest());
+          }
         }
         dmaSetMaskBytes(_fd, maskBytes);
       }
       memset(_directWrites, 0, sizeof(_directWrites));
       // if using SrpV3 create the proto object
       if (_srpV3) {
-        _proto = new SrpV3::Protocol(_fd, _portOffset);
+        _proto = new SrpV3::Protocol(_fd, usesDataDriver());
       }
       // End MCB changes.
       printf("Pgp::Pgp(fd(%d)), offset(%u) %u\n", _fd, _portOffset, vcm);
@@ -108,9 +110,10 @@ namespace Pds {
       if ((retSize = ::read(_fd, &dmaReadData, sizeof(DmaReadData))) >= 0) {
           *size = (dmaReadData.ret / sizeof(uint32_t));
           if (dmaReadData.error) {
+            Destination dest(usesDataDriver(), dmaReadData.dest);
             printf("Pgp::read error fifoErr(%u), lengthErr(%u), maxErr(%u), busErr(%u)\n",
                     dmaReadData.error&DMA_ERR_FIFO, dmaReadData.error&DMA_ERR_LEN, dmaReadData.error&DMA_ERR_MAX, dmaReadData.error&DMA_ERR_BUS);
-            printf("\tpgpLane(%u), pgpVc(%u), size(%d)\n", pgpGetLane(dmaReadData.dest), pgpGetVc(dmaReadData.dest), *size);
+            printf("\tpgpLane(%u), pgpVc(%u), size(%d)\n", dest.lane(), dest.vc(), *size);
             ret = 0;
           } else {
               bool hardwareFailure = false;
@@ -162,10 +165,11 @@ namespace Pds {
             readRet = dmaReadData.ret;
             if ((ret->waiting() == Pds::Pgp::PgpRSBits::Waiting) || (ret->opcode() == Pds::Pgp::PgpRSBits::read)) {
               found = true;
+              Destination dest(usesDataDriver(), dmaReadData.dest);
               if (dmaReadData.error) {
                 printf("Pgp::read error fifoErr(%u), lengthErr(%u), maxErr(%u), busErr(%u)\n",
                        dmaReadData.error&DMA_ERR_FIFO, dmaReadData.error&DMA_ERR_LEN, dmaReadData.error&DMA_ERR_MAX, dmaReadData.error&DMA_ERR_BUS);
-                printf("\tpgpLane(%u), pgpVc(%u)\n", pgpGetLane(dmaReadData.dest), pgpGetVc(dmaReadData.dest));
+                printf("\tpgpLane(%u), pgpVc(%u)\n", dest.lane(), dest.vc());
                 ret = 0;
               } else {
                 if (readRet != (int)retSize) {
@@ -198,8 +202,9 @@ namespace Pds {
           found = true;  // we might as well give up!
           ret = 0;
           if (sret < 0) {
+            Destination dest(usesDataDriver(), dmaReadData.dest);
             perror("Pgp::read select error: ");
-            printf("\tpgpLane(%u), pgpVc(%u)\n", pgpGetLane(dmaReadData.dest), pgpGetVc(dmaReadData.dest));
+            printf("\tpgpLane(%u), pgpVc(%u)\n", dest.lane(), dest.vc());
           } else {
             printf("Pgp::read select timed out!\n");
           }
@@ -268,35 +273,37 @@ namespace Pds {
       }
     }
 
-    unsigned Pgp::writeData(Destination* dest, uint32_t data, bool printFlag) {
+    unsigned Pgp::writeData(Destination dest, uint32_t data, bool printFlag) {
       DmaWriteData  tx;
+      dest.dest(dest.lane() + portOffset(), dest.vc());
       tx.is32   = sizeof(&tx) == 4;
-      tx.dest   = (dest->vc() & 3) | (((dest->lane() & (isG3() ? 7: 3)) + portOffset())<<2);
+      tx.dest   = dest.dest();
       tx.size   = sizeof(data);
       tx.data   = (uint64_t)&data;
       tx.flags  = 0;
       tx.index  = 0;
       if (printFlag) printf("Pgp::write of value %u to lane(%u), vc(%u)\n",
                             data,
-                            (dest->lane() & (isG3() ? 7: 3)) + portOffset(),
-                            dest->vc() & 3);
+                            dest.lane(),
+                            dest.vc());
       write(_fd, &tx, sizeof(tx));
-      _directWrites[dest->vc() & 3] = data;
+      _directWrites[dest.vc()] = data;
       return Success;
     }
 
-    unsigned Pgp::writeDataBlock(Destination* dest, uint32_t* data, unsigned size, bool printFlag) {
+    unsigned Pgp::writeDataBlock(Destination dest, uint32_t* data, unsigned size, bool printFlag) {
       DmaWriteData  tx;
+      dest.dest(dest.lane() + portOffset(), dest.vc());
       tx.is32   = sizeof(&tx) == 4;
-      tx.dest   = (dest->vc() & 3) | (((dest->lane() & (isG3() ? 7: 3)) + portOffset())<<2);
+      tx.dest   = dest.dest();
       tx.size   = sizeof(uint32_t) * size;
       tx.data   = (uint64_t)data;
       tx.flags  = 0;
       tx.index  = 0;
       if (printFlag) {
         printf("Pgp::write of data to lane(%u), vc(%u):",
-               (dest->lane() & (isG3() ? 7: 3)) + portOffset(),
-               dest->vc() & 3);
+               dest.lane(),
+               dest.vc());
         for(unsigned i=0; i<size; i++) {
           printf(" %u", data[i]);
         }
@@ -306,22 +313,22 @@ namespace Pds {
       return Success;
     }
 
-    unsigned Pgp::lastWriteData(Destination* dest, uint32_t* retp) {
-      *retp = _directWrites[dest->vc() & 3];
+    unsigned Pgp::lastWriteData(Destination dest, uint32_t* retp) {
+      *retp = _directWrites[dest.vc()];
       return Success;
     }
 
     unsigned Pgp::writeRegister(
-        Destination* dest,
+        Destination dest,
         unsigned addr,
         uint32_t data,
         bool printFlag,
         Pds::Pgp::PgpRSBits::waitState w) {
+      dest.dest(dest.lane() + portOffset(), dest.vc());
       if (_srpV3) {
         return _proto->writeRegister(dest, addr, data);
       }
       Pds::Pgp::RegisterSlaveExportFrame rsef = Pds::Pgp::RegisterSlaveExportFrame(
-          this,
           Pds::Pgp::PgpRSBits::write,
           dest,
           addr,
@@ -329,16 +336,17 @@ namespace Pds {
           data,
           w);
       if (printFlag) rsef.print();
-      return rsef.post(_fd, sizeof(rsef)/sizeof(uint32_t));
+      return rsef.post(this, sizeof(rsef)/sizeof(uint32_t));
     }
 
     unsigned Pgp::writeRegisterBlock(
-        Destination* dest,
+        Destination dest,
         unsigned addr,
         uint32_t* data,
         unsigned inSize,  // the size of the block to be exported
         Pds::Pgp::PgpRSBits::waitState w,
         bool pf) {
+      dest.dest(dest.lane() + portOffset(), dest.vc());
       if (_srpV3) {
         return _proto->writeRegisterBlock(dest, addr, data, inSize);
       }
@@ -347,7 +355,6 @@ namespace Pds {
       uint32_t myArray[size];
       Pds::Pgp::RegisterSlaveExportFrame* rsef = 0;
       rsef = new (myArray) Pds::Pgp::RegisterSlaveExportFrame(
-              this,
               Pds::Pgp::PgpRSBits::write,
               dest,
               addr,
@@ -357,22 +364,22 @@ namespace Pds {
       memcpy(rsef->array(), data, inSize*sizeof(uint32_t));
       rsef->array()[inSize] = 0;
       if (pf) rsef->print(0, size);
-      return rsef->post(_fd, size);
+      return rsef->post(this, size);
     }
 
     unsigned Pgp::readRegister(
-        Destination* dest,
+        Destination dest,
         unsigned addr,
         unsigned tid,
         uint32_t* retp,
         unsigned size,
         bool pf) {
+      dest.dest(dest.lane() + portOffset(), dest.vc());
       if (_srpV3) {
         return _proto->readRegister(dest, addr, tid, retp, size);
       }
       Pds::Pgp::RegisterSlaveImportFrame* rsif;
       Pds::Pgp::RegisterSlaveExportFrame  rsef = Pds::Pgp::RegisterSlaveExportFrame(
-        this,
         Pds::Pgp::PgpRSBits::read,
         dest,
         addr,
@@ -380,7 +387,7 @@ namespace Pds {
         size - 1,  // zero = one uint32_t, etc.
         Pds::Pgp::PgpRSBits::Waiting);
       if (pf) rsef.print();
-      if (rsef.post(_fd, sizeof(Pds::Pgp::RegisterSlaveExportFrame)/sizeof(uint32_t),pf) != Success) {
+      if (rsef.post(this, sizeof(Pds::Pgp::RegisterSlaveExportFrame)/sizeof(uint32_t),pf) != Success) {
         printf("Pgp::readRegister failed, export frame follows.\n");
         rsef.print(0, sizeof(Pds::Pgp::RegisterSlaveExportFrame)/sizeof(uint32_t));
         return  Failure;
@@ -395,7 +402,7 @@ namespace Pds {
         if (pf) rsif->print(size + 3);
         if (addr != rsif->addr()) {
           printf("Pds::Pgp::readRegister out of order response lane=%u, vc=%u, addr=0x%x, tid=%u, errorCount=%u\n",
-                 dest->lane(), dest->vc(), addr, tid, ++errorCount);
+                 dest.lane(), dest.vc(), addr, tid, ++errorCount);
           rsif->print(size + 3);
           if (errorCount > 5) return Failure;
         } else {  // copy the data
@@ -437,8 +444,9 @@ namespace Pds {
         }
       } while ((ret > 0) && (count < 100));
       if (count && printFlag) {
+          Destination dest(usesDataDriver(), dmaReadData.dest);
           printf("\tflushInputQueue: pgpCardRx count(%u) lane(%u) vc(%u) rxSize(%u) fifo(%s) lengthErr(%s)\n",
-                 count, pgpGetLane(dmaReadData.dest), pgpGetVc(dmaReadData.dest), dmaReadData.size,
+                 count, dest.lane(), dest.vc(), dmaReadData.size,
                  dmaReadData.error&DMA_ERR_FIFO ? "true" : "false", dmaReadData.error&DMA_ERR_LEN ? "true" : "false");
           printf("\t\t");
           printf("%u\n", dmaReadData.size);

--- a/pgpLib/src/RegisterSlaveExportFrame.cc
+++ b/pgpLib/src/RegisterSlaveExportFrame.cc
@@ -21,9 +21,8 @@ namespace Pds {
     unsigned  RegisterSlaveExportFrame::errors = 0;
 
     RegisterSlaveExportFrame::RegisterSlaveExportFrame(
-        Pgp *pgp,                                                       
         PgpRSBits::opcode o,
-        Destination* dest,
+        const Destination& dest,
         unsigned a,
         unsigned transID,
         uint32_t da,
@@ -32,9 +31,9 @@ namespace Pds {
       bits._tid     = transID & ((1<<23)-1);
       bits._waiting = w;
 //      printf("RegisterSlaveExportFrame::RegisterSlaveExportFrame() lane %u offset %u\n", dest->lane(), pgp->portOffset());
-      bits._lane   = (dest->lane() & (pgp->isG3() ? 7 : 3)) + pgp->portOffset();
+      bits._lane   = dest.lane();
       bits.mbz     = 0;
-      bits._vc     = dest->vc() & 3;
+      bits._vc     = dest.vc();
       bits.oc      = o;
       bits._addr   = a & addrMask;
       _data        = da;  // NB, for read request size of block requested minus one is placed in data field
@@ -42,15 +41,16 @@ namespace Pds {
     }
 
     // parameter is the size of the post in number of 32 bit words
-    unsigned RegisterSlaveExportFrame::post(int _fd, __u32 size, bool pf) {
+    unsigned RegisterSlaveExportFrame::post(Pgp *pgp, __u32 size, bool pf) {
       struct timeval  timeout;
       DmaWriteData    dmaWriteData;
       int             ret;
       fd_set          fds;
+      int             _fd = pgp->fd();
 
       dmaWriteData.is32   = (sizeof(&dmaWriteData) == 4);
       dmaWriteData.flags  = 0;
-      dmaWriteData.dest   = this->bits._vc | (this->bits._lane<<2);
+      dmaWriteData.dest   = Destination(pgp->usesDataDriver(), this->bits._lane, this->bits._vc).dest();
       dmaWriteData.index  = 0;
       dmaWriteData.size   = size * sizeof(uint32_t);
       dmaWriteData.data   = (__u64)this;

--- a/pgpLib/src/SrpV3.cc
+++ b/pgpLib/src/SrpV3.cc
@@ -20,18 +20,7 @@ enum {Success=0, Failure=1};
 
 static const unsigned SelectSleepTimeUSec=100000;
 
-static void printError(unsigned error, unsigned dest)
-{
-  printf("SrpV3::read error eofe(%s), fifo(%s), len(%s), bus%s\n",
-         error & PGP_ERR_EOFE ? "true" : "false",
-         error & DMA_ERR_FIFO ? "true" : "false",
-         error & DMA_ERR_LEN ? "true" : "false",
-         error & DMA_ERR_BUS ? "true" : "false");
-  printf("\tpgpLane(%u), pgpVc(%u)\n", pgpGetLane(dest), pgpGetVc(dest));
-}
-
 RegisterSlaveFrame::RegisterSlaveFrame(Pds::Pgp::PgpRSBits::opcode oc,
-                                       Destination* dest,
                                        uint64_t     addr,
                                        unsigned     tid,
                                        uint32_t     size) :
@@ -49,9 +38,9 @@ void RegisterSlaveFrame::print(unsigned nw) const {
   printf("\n");
 }
 
-Protocol::Protocol(int fd, unsigned lane) :
-  _fd    (fd),
-  _lane  (lane)
+Protocol::Protocol(int fd, bool usesDataDriver) :
+  _fd(fd),
+  _usesDataDriver(usesDataDriver)
 {
   memset(_readBuffer, 0, BufferWords*sizeof(unsigned));
 }
@@ -90,8 +79,14 @@ Pds::Pgp::RegisterSlaveImportFrame* Protocol::read(unsigned size)
           reinterpret_cast<SrpV3::RegisterSlaveFrame*>(_readBuffer);
         if (rsf->opcode() == PgpRSBits::read) {
           found = true;
+          Destination dest(usesDataDriver(), pgpCardRx.dest);
           if (pgpCardRx.error) {
-            printError(pgpCardRx.error, pgpCardRx.dest);
+            printf("SrpV3::read error eofe(%s), fifo(%s), len(%s), bus%s\n",
+                   pgpCardRx.error & PGP_ERR_EOFE ? "true" : "false",
+                   pgpCardRx.error & DMA_ERR_FIFO ? "true" : "false",
+                   pgpCardRx.error & DMA_ERR_LEN ? "true" : "false",
+                   pgpCardRx.error & DMA_ERR_BUS ? "true" : "false");
+            printf("\tpgpLane(%u), pgpVc(%u)\n", dest.lane(), dest.vc());
           } else {
             //            rsf->print(pgpCardRx.ret/sizeof(uint32_t));
             // Sometimes we are missing the trailing word
@@ -117,7 +112,6 @@ Pds::Pgp::RegisterSlaveImportFrame* Protocol::read(unsigned size)
                 // Format the SrpV0 frame header
                 SrpV3::RegisterSlaveFrame rsfv = *rsf;
                 ret = reinterpret_cast<Pds::Pgp::RegisterSlaveImportFrame*>(_readBuffer+3);
-                Destination dest(pgpCardRx.dest);
                 ret->bits._vc      = dest.vc();
                 ret->bits.mbz      = 0;
                 ret->bits._lane    = dest.lane();
@@ -136,8 +130,9 @@ Pds::Pgp::RegisterSlaveImportFrame* Protocol::read(unsigned size)
     } else {
       found = true;  // we might as well give up!
       if (sret < 0) {
+        Destination dest(usesDataDriver(), pgpCardRx.dest);
         perror("SrpV3::read select error: ");
-        printf("\tpgpLane(%u), pgpVc(%u)\n", pgpCardRx.dest>>2, pgpCardRx.dest&3);
+        printf("\tpgpLane(%u), pgpVc(%u)\n", dest.lane(), dest.vc());
       } else {
         printf("SrpV3::read select timed out! fd[%u]\n", _fd);
       }
@@ -146,19 +141,18 @@ Pds::Pgp::RegisterSlaveImportFrame* Protocol::read(unsigned size)
   return ret;
 }
 
-unsigned Protocol::writeRegister(Destination* dest,
-                                 unsigned     addr,
-                                 uint32_t     data) {
+unsigned Protocol::writeRegister(const Destination& dest,
+                                 unsigned           addr,
+                                 uint32_t           data) {
 #ifdef DBUG
-  printf("SrpV3::writeRegister dest_lane[%x] addr[%x] fd[%u] proto_lane[%u] this[%p]\n",
-         dest->lane(), addr, _fd, _lane, this);
+  printf("SrpV3::writeRegister lane[%x] vc[%x] addr[%x] fd[%u] this[%p]\n",
+         dest.lane(), dest.vc(), addr, _fd, this);
 #endif
 
   unsigned tid = 0x6969;
   unsigned size = 1;
   SrpV3::RegisterSlaveFrame* hdr = 
     new (_writeBuffer) SrpV3::RegisterSlaveFrame(PgpRSBits::write, 
-                                                 dest, 
                                                  addr, 
                                                  tid, 
                                                  size);
@@ -176,7 +170,7 @@ unsigned Protocol::writeRegister(Destination* dest,
   struct DmaWriteData  pgpCardTx;
   pgpCardTx.is32   = (sizeof(&pgpCardTx) == 4);
   pgpCardTx.flags  = 0;
-  pgpCardTx.dest   = dest->vc() | ((dest->lane() + _lane)<<2);
+  pgpCardTx.dest   = dest.dest();
   pgpCardTx.index  = 0;
   pgpCardTx.size   = sizeof(*hdr) + size*sizeof(uint32_t);
   pgpCardTx.data   = (__u64)hdr;
@@ -195,17 +189,17 @@ unsigned Protocol::writeRegister(Destination* dest,
   return Success;
 }
 
-unsigned Protocol::readRegister(Destination* dest,
-                                unsigned addr,
-                                unsigned tid,
-                                uint32_t* retp,
-                                unsigned size) {
+unsigned Protocol::readRegister(const Destination& dest,
+                                unsigned           addr,
+                                unsigned           tid,
+                                uint32_t*          retp,
+                                unsigned           size) {
 #ifdef DBUG
-  printf("SrpV3::readRegister dest_lane[%u] addr[%u] fd[%u] this[%p]\n",
-         dest->lane(), addr, _fd, this);
+  printf("SrpV3::writeRegister lane[%x] vc[%x] addr[%x] fd[%u] this[%p]\n",
+         dest.lane(), dest.vc(), addr, _fd, this);
 #endif
 
-  SrpV3::RegisterSlaveFrame hdr(PgpRSBits::read, dest, addr, tid, size);
+  SrpV3::RegisterSlaveFrame hdr(PgpRSBits::read, addr, tid, size);
   // post
   // Wait for write ready
   struct timeval  timeout;
@@ -218,7 +212,7 @@ unsigned Protocol::readRegister(Destination* dest,
   struct DmaWriteData  pgpCardTx;
   pgpCardTx.is32   = (sizeof(&pgpCardTx) == 4);
   pgpCardTx.flags  = 0;
-  pgpCardTx.dest   = dest->vc() | ((dest->lane() + _lane)<<2);
+  pgpCardTx.dest   = dest.dest();
   pgpCardTx.index  = 0;
   pgpCardTx.size   = sizeof(hdr);
   pgpCardTx.data   = (__u64)&hdr;
@@ -244,7 +238,7 @@ unsigned Protocol::readRegister(Destination* dest,
     }
     if ((addr&0x3fffffff) != rsif->addr()) {  // Can only test lowest 24 bits of addr
       printf("SrpV3::readRegister out of order response lane=%u, vc=%u, addr=0x%x(0x%x), tid=0x%x(0x%x), errorCount=%u\n",
-             dest->lane(), dest->vc(), addr, rsif->addr(), tid, rsif->tid(), ++errorCount);
+             dest.lane(), dest.vc(), addr, rsif->addr(), tid, rsif->tid(), ++errorCount);
       if (errorCount > 5) return Failure;
     } else {  // copy the data
       memcpy(retp, rsif->array(), size * sizeof(uint32_t));
@@ -253,19 +247,18 @@ unsigned Protocol::readRegister(Destination* dest,
   }
 }
 
-unsigned Protocol::writeRegisterBlock(Destination* dest,
-                                      unsigned     addr,
-                                      uint32_t*    data,
-                                      unsigned     size) {
+unsigned Protocol::writeRegisterBlock(const Destination& dest,
+                                      unsigned           addr,
+                                      uint32_t*          data,
+                                      unsigned           size) {
 #ifdef DBUG
-  printf("SrpV3::writeRegister dest_lane[%x] addr[%x] fd[%u] proto_lane[%u] this[%p]\n",
-         dest->lane(), addr, _fd, _lane, this);
+  printf("SrpV3::writeRegister lane[%x] vc[%x] addr[%x] fd[%u] this[%p]\n",
+         dest.lane(), dest.vc(), addr, _fd, this);
 #endif
 
   unsigned tid = 0x6970;
   SrpV3::RegisterSlaveFrame* hdr =
     new (_writeBuffer) SrpV3::RegisterSlaveFrame(PgpRSBits::write,
-                                                 dest,
                                                  addr,
                                                  tid,
                                                  size);
@@ -283,7 +276,7 @@ unsigned Protocol::writeRegisterBlock(Destination* dest,
   struct DmaWriteData  pgpCardTx;
   pgpCardTx.is32   = (sizeof(&pgpCardTx) == 4);
   pgpCardTx.flags  = 0;
-  pgpCardTx.dest   = dest->vc() | ((dest->lane() + _lane)<<2);
+  pgpCardTx.dest   = dest.dest();
   pgpCardTx.index  = 0;
   pgpCardTx.size   = sizeof(*hdr) + size*sizeof(uint32_t);
   pgpCardTx.data   = (__u64)hdr;

--- a/pgpLib/src/SrpV3.cc
+++ b/pgpLib/src/SrpV3.cc
@@ -156,7 +156,7 @@ unsigned Protocol::writeRegister(const Destination& dest,
                                                  addr, 
                                                  tid, 
                                                  size);
-  memcpy(hdr+1, &data, size*sizeof(uint32_t));
+  memcpy(static_cast<void*>(hdr+1), &data, size*sizeof(uint32_t));
 
   // post
   // Wait for write ready
@@ -262,7 +262,7 @@ unsigned Protocol::writeRegisterBlock(const Destination& dest,
                                                  addr,
                                                  tid,
                                                  size);
-  memcpy(hdr+1, data, size*sizeof(uint32_t));
+  memcpy(static_cast<void*>(hdr+1), data, size*sizeof(uint32_t));
 
   // post
   // Wait for write ready

--- a/pgpLib/src/drvPGP.cpp
+++ b/pgpLib/src/drvPGP.cpp
@@ -176,7 +176,7 @@ public:
             cfg[seq].lane = lane;
             cfg[seq].vc   = vc;
             cfg[seq].addr = addr;
-            cfg[seq].dest = new Destination((lane << 2) | (vc & 3));
+            cfg[seq].dest = new Destination(pgp->usesDataDriver(), lane, vc);
         }
     }
     void addCfgOut(struct longoutRecord *r, int lane, int vc, int addr, int seq) {
@@ -186,7 +186,7 @@ public:
             cfg[seq].lane = lane;
             cfg[seq].vc   = vc;
             cfg[seq].addr = addr;
-            cfg[seq].dest = new Destination((lane << 2) | (vc & 3));
+            cfg[seq].dest = new Destination(pgp->usesDataDriver(), lane, vc);
         }
     }
     void *addSrc(int lane, int vc, char *trigger, PGP_rcvfunc rcvfunc, PGP_enfunc enfunc, void *dev_token) {
@@ -243,10 +243,10 @@ public:
             if (cfg[i].val) {
                 if (cfg[i].addr == Pgp::DirectWrite) {
                   printf("%d: Writing 0x%x directly to vc %d\n", i, cfg[i].val->val, cfg[i].vc);
-                  pgp->writeData(cfg[i].dest, cfg[i].val->val, PGP_reg_debug);
+                  pgp->writeData(*cfg[i].dest, cfg[i].val->val, PGP_reg_debug);
                 } else {
                   printf("%d: Writing 0x%x to address %d\n", i, cfg[i].val->val, cfg[i].addr);
-                  pgp->writeRegister(cfg[i].dest, cfg[i].addr, cfg[i].val->val, PGP_reg_debug, PgpRSBits::notWaiting);
+                  pgp->writeRegister(*cfg[i].dest, cfg[i].addr, cfg[i].val->val, PGP_reg_debug, PgpRSBits::notWaiting);
                 }
             } else {
                 printf("%d: WARNING: No write entry!!\n", i);
@@ -255,9 +255,9 @@ public:
         for (i = 0; i <= cfgmax; i++) {
             if (cfg[i].rbv && cfg[i].addr != Pgp::DirectWrite) {
                 if (cfg[i].addr == Pgp::DirectWrite) {
-                  pgp->lastWriteData(cfg[i].dest, &val);
+                  pgp->lastWriteData(*cfg[i].dest, &val);
                 } else {
-                  pgp->readRegister(cfg[i].dest, cfg[i].addr, 0x4200 + i, &val, 1, PGP_reg_debug);
+                  pgp->readRegister(*cfg[i].dest, cfg[i].addr, 0x4200 + i, &val, 1, PGP_reg_debug);
                 }
                 printf("Read 0x%x from address %d\n", val, cfg[i].addr);
                 cfg[i].rbv->val = val;
@@ -375,19 +375,19 @@ void PGP_receive_data(void *pgp_token, pgp_data *data) {
 unsigned PGP_register_write(void *pgp_token, int lane, int vc, unsigned addr, unsigned val)
 {
     PGPCARD *pgp = (PGPCARD *)pgp_token;
-    Destination d((lane << 2) | (vc & 3));
+    Destination d(pgp->pgp->usesDataDriver(), lane, vc);
 
     printf("Writing 0x%x to address %d\n", val, addr);
-    return pgp->pgp->writeRegister(&d, addr, val, PGP_reg_debug, PgpRSBits::notWaiting);
+    return pgp->pgp->writeRegister(d, addr, val, PGP_reg_debug, PgpRSBits::notWaiting);
 }
 
 unsigned PGP_register_read(void *pgp_token, int lane, int vc, unsigned addr, unsigned *val)
 {
     PGPCARD *pgp = (PGPCARD *)pgp_token;
-    Destination d((lane << 2) | (vc & 3));
+    Destination d(pgp->pgp->usesDataDriver(), lane, vc);
     unsigned result;
 
-    result = pgp->pgp->readRegister(&d, addr, (lane << 12) + (vc << 8) + addr, val, 1, PGP_reg_debug);
+    result = pgp->pgp->readRegister(d, addr, (lane << 12) + (vc << 8) + addr, val, 1, PGP_reg_debug);
     if (!result)
         printf("Read 0x%x from address %d\n", *val, addr);
     else
@@ -398,23 +398,23 @@ unsigned PGP_register_read(void *pgp_token, int lane, int vc, unsigned addr, uns
 unsigned PGP_write_data(void *pgp_token, int lane, int vc, unsigned val)
 {
     PGPCARD *pgp = (PGPCARD *)pgp_token;
-    Destination d((lane << 2) | (vc & 3));
+    Destination d(pgp->pgp->usesDataDriver(), lane, vc);
 
     printf("Writing 0x%x to vc %d\n", val, vc);
-    return pgp->pgp->writeData(&d, val, PGP_reg_debug);
+    return pgp->pgp->writeData(d, val, PGP_reg_debug);
 }
 
 unsigned PGP_write_data_bulk(void *pgp_token, int lane, int vc, unsigned* data, unsigned size)
 {
     PGPCARD *pgp = (PGPCARD *)pgp_token;
-    Destination d((lane << 2) | (vc & 3));
+    Destination d(pgp->pgp->usesDataDriver(), lane, vc);
 
     printf("Writing");
     for (unsigned i=0; i<size; i++) {
       printf(" 0x%x", data[i]);
     }
     printf(" to vc %d\n", vc);
-    return pgp->pgp->writeDataBlock(&d, data, size, PGP_reg_debug);
+    return pgp->pgp->writeDataBlock(d, data, size, PGP_reg_debug);
 }
 
 void PGP_pause(void *pgp_token)
@@ -436,11 +436,10 @@ void PGP_readreg(int mask, int vcm, int srpV3, unsigned int addr, unsigned int* 
         printf("PGP_writereg: illegal vcm = %x\n", vcm);
         return;
     }
-    Destination d(bit[vcm]); // Lane is always zero! */
-    Pgp *pgp = NULL;
     try {
-        pgp = new Pgp(mask, vcm, srpV3);
-        pgp->readRegister(&d, addr, 0x4200, value, 1, PGP_reg_debug);
+        Pgp *pgp = new Pgp(mask, vcm, srpV3);
+        Destination d(pgp->usesDataDriver(), bit[vcm]); // Lane is always zero! */
+        pgp->readRegister(d, addr, 0x4200, value, 1, PGP_reg_debug);
         delete pgp;
     }
     catch(char const *s) {
@@ -454,13 +453,11 @@ void PGP_readreg_bulk(int mask, int vcm, int srpV3, pgp_reg_rdata* reg_data, uns
         printf("PGP_writereg: illegal vcm = %x\n", vcm);
         return;
     }
-    Destination d(bit[vcm]); // Lane is always zero! */
-    Pgp *pgp = NULL;
-    unsigned int i;
     try {
-        pgp = new Pgp(mask, vcm, srpV3);
-        for(i=0; i<size; i++) {
-            pgp->readRegister(&d, reg_data[i].addr, 0x4200 + i, reg_data[i].value, reg_data[i].size, PGP_reg_debug);
+        Pgp *pgp = new Pgp(mask, vcm, srpV3);
+        Destination d(pgp->usesDataDriver(), bit[vcm]); // Lane is always zero! */
+        for(unsigned int i=0; i<size; i++) {
+            pgp->readRegister(d, reg_data[i].addr, 0x4200 + i, reg_data[i].value, reg_data[i].size, PGP_reg_debug);
         }
         delete pgp;
     }
@@ -475,11 +472,10 @@ void PGP_writereg(int mask, int vcm, int srpV3, unsigned int addr, unsigned int 
         printf("PGP_writereg: illegal vcm = %x\n", vcm);
         return;
     }
-    Destination d(bit[vcm]); // Lane is always zero! */
-    Pgp *pgp = NULL;
     try {
-        pgp = new Pgp(mask, vcm, srpV3);
-        pgp->writeRegister(&d, addr, value, PGP_reg_debug, PgpRSBits::notWaiting);
+        Pgp *pgp = new Pgp(mask, vcm, srpV3);
+        Destination d(pgp->usesDataDriver(), bit[vcm]); // Lane is always zero! */
+        pgp->writeRegister(d, addr, value, PGP_reg_debug, PgpRSBits::notWaiting);
         delete pgp;
     }
     catch(char const *s) {
@@ -493,13 +489,11 @@ void PGP_writereg_bulk(int mask, int vcm, int srpV3, pgp_reg_data* reg_data, uns
         printf("PGP_writereg: illegal vcm = %x\n", vcm);
         return;
     }
-    Destination d(bit[vcm]); // Lane is always zero! */
-    Pgp *pgp = NULL;
-    unsigned int i;
     try {
-        pgp = new Pgp(mask, vcm, srpV3);
-        for (i=0; i<size; i++) {
-          pgp->writeRegister(&d, reg_data[i].addr, reg_data[i].value, PGP_reg_debug, PgpRSBits::notWaiting);
+        Pgp *pgp = new Pgp(mask, vcm, srpV3);
+        Destination d(pgp->usesDataDriver(), bit[vcm]); // Lane is always zero! */
+        for (unsigned int i=0; i<size; i++) {
+          pgp->writeRegister(d, reg_data[i].addr, reg_data[i].value, PGP_reg_debug, PgpRSBits::notWaiting);
         }
         delete pgp;
     }
@@ -514,11 +508,10 @@ void PGP_writedata(int mask, int vcm, unsigned int* data, unsigned int size)
     printf("PGP_writereg: illegal vcm = %x\n", vcm);
     return;
   }
-  Destination d(bit[vcm]); // Lane is always zero! */
-  Pgp *pgp = NULL;
   try {
-    pgp = new Pgp(mask, vcm, false);
-    pgp->writeDataBlock(&d, data, size, PGP_reg_debug);
+    Pgp *pgp = new Pgp(mask, vcm, false);
+    Destination d(pgp->usesDataDriver(), bit[vcm]); // Lane is always zero! */
+    pgp->writeDataBlock(d, data, size, PGP_reg_debug);
     delete pgp;
   }
   catch(char const *s) {

--- a/pgpLib/src/pds/pgp/Destination.hh
+++ b/pgpLib/src/pds/pgp/Destination.hh
@@ -8,7 +8,7 @@
 #ifndef DESTINATION_HH_
 #define DESTINATION_HH_
 
-#include <string.h>
+#include <string>
 
 namespace Pds {
 
@@ -16,40 +16,22 @@ namespace Pds {
 
     class Destination {
       public:
-        Destination() { _dest = 0; };
-        Destination(unsigned d) { _dest = d; };
-        virtual ~Destination() {};
+        Destination();
+        Destination(bool datadev, unsigned d);
+        Destination(bool datadev, unsigned lane, unsigned vc);
+        virtual ~Destination();
 
       public:
-        void dest(unsigned d) { _dest = d; }
-        unsigned dest() { return _dest; }
-        virtual unsigned lane() { return( (_dest>>2) & 0x7); }
-        virtual unsigned vc() { return _dest & 0x3; }
-        virtual const char*    name() {
-          static char _ret[80];
-          static const char* _lanes[9] = {
-              "Lane 0, ",
-              "Lane 1, ",
-              "Lane 2, ",
-              "Lane 3, ",
-              "Lane 4, ",
-              "Lane 5, ",
-              "Lane 6, ",
-              "Lane 7, ",
-              "--INVALID--"
-          };
-          static const char* _vcs[5] = {
-              "VC 0",
-              "VC 1",
-              "VC 2",
-              "VC 3",
-              "--INVALID--"
-          };
-          strcpy(_ret, _lanes[lane()]);
-          return strcat(_ret, _vcs[vc()]);
-        }
+        void offset(unsigned o);
+        void dest(unsigned d);
+        void dest(unsigned lane, unsigned vc);
+        unsigned dest() const;
+        virtual unsigned lane() const;
+        virtual unsigned vc() const;
+        virtual std::string name() const;
 
       protected:
+        unsigned _offset;
         unsigned _dest;
     };
 

--- a/pgpLib/src/pds/pgp/Pgp.hh
+++ b/pgpLib/src/pds/pgp/Pgp.hh
@@ -33,23 +33,23 @@ namespace Pds {
         Pds::Pgp::RegisterSlaveImportFrame* read(
                           unsigned size = (sizeof(Pds::Pgp::RegisterSlaveImportFrame)/sizeof(uint32_t)));
         unsigned       writeData(
-                          Destination*,
+                          Destination,
                           uint32_t,
                           bool pf=false);
         unsigned       writeDataBlock(
-                          Destination*,
+                          Destination,
                           uint32_t*,
                           unsigned size,
                           bool pf=false);
         unsigned       writeRegister(
-                          Destination*,
+                          Destination,
                           unsigned,
                           uint32_t,
                           bool pf = false,
                           Pds::Pgp::PgpRSBits::waitState = Pds::Pgp::PgpRSBits::notWaiting);
         // NB size should be the size of data to be written in uint32_t's
         unsigned       writeRegisterBlock(
-                          Destination*,
+                          Destination,
                           unsigned,
                           uint32_t*,
                           unsigned size = 1,
@@ -58,7 +58,7 @@ namespace Pds {
 
         // NB size should be the size of the block requested in uint32_t's
         unsigned      readRegister(
-                          Destination*,
+                          Destination,
                           unsigned,
                           unsigned,
                           uint32_t*,
@@ -71,7 +71,7 @@ namespace Pds {
                           bool printFlag=false);
         unsigned      readStatus( void * );
         unsigned      flushInputQueue(bool printFlag=false);
-        unsigned      lastWriteData(Destination*, uint32_t*);
+        unsigned      lastWriteData(Destination, uint32_t*);
 
         void          portOffset(unsigned p) { _portOffset = p;    }
         unsigned      portOffset() const     { return _portOffset; }

--- a/pgpLib/src/pds/pgp/RegisterSlaveExportFrame.hh
+++ b/pgpLib/src/pds/pgp/RegisterSlaveExportFrame.hh
@@ -24,12 +24,11 @@ namespace Pds {
         enum masks {addrMask=(1<<30)-1};
 
         RegisterSlaveExportFrame(
-            Pgp *pgp,
-            PgpRSBits::opcode,   // opcode
-            Destination* dest,   // Destination
-            unsigned,            // address
-            unsigned,            // transaction ID
-            uint32_t=0,          // data
+            PgpRSBits::opcode,        // opcode
+            const Destination& dest,  // Destination
+            unsigned,                 // address
+            unsigned,                 // transaction ID
+            uint32_t=0,               // data
             PgpRSBits::waitState=PgpRSBits::notWaiting);
 
         ~RegisterSlaveExportFrame() {};
@@ -42,7 +41,7 @@ namespace Pds {
         unsigned tid()                            {return bits._tid;}
         void waiting(PgpRSBits::waitState w)      {bits._waiting = w;}
         uint32_t* array()                         {return (uint32_t*)&_data;}
-        unsigned post(int _fd, __u32 size, bool pf=false);  // the size of the entire header + payload in number of 32 bit words
+        unsigned post(Pgp *pgp, __u32 size, bool pf=false);  // the size of the entire header + payload in number of 32 bit words
         void print(unsigned = 0, unsigned = 4);
 
 

--- a/pgpLib/src/pds/pgp/SrpV3.hh
+++ b/pgpLib/src/pds/pgp/SrpV3.hh
@@ -15,7 +15,6 @@ namespace Pds {
       public:
         RegisterSlaveFrame(
             PgpRSBits::opcode,   // opcode
-            Destination* dest,   // Destination
             uint64_t,            // address
             unsigned,            // transaction ID
             uint32_t=0);         // data
@@ -38,28 +37,28 @@ namespace Pds {
 
       class Protocol {
       public:
-        Protocol(int fd, unsigned lane);
+        Protocol(int fd, bool usesDataDriver);
       public:
-        unsigned      writeRegister( Destination* dest,
-                                     unsigned     addr,
-                                     uint32_t     val);
-        unsigned      readRegister( Destination* dest,
-                                    unsigned     addr,
-                                    unsigned     tid,
-                                    uint32_t*    retp,
-                                    unsigned     size=1);
-        unsigned      writeRegisterBlock( Destination* dest,
-                                          unsigned     addr,
-                                          uint32_t*    val,
-                                          unsigned     size);
+        unsigned      writeRegister( const Destination& dest,
+                                     unsigned           addr,
+                                     uint32_t           val);
+        unsigned      readRegister( const Destination& dest,
+                                    unsigned           addr,
+                                    unsigned           tid,
+                                    uint32_t*          retp,
+                                    unsigned           size=1);
+        unsigned      writeRegisterBlock( const Destination& dest,
+                                          unsigned           addr,
+                                          uint32_t*          val,
+                                          unsigned           size);
         RegisterSlaveImportFrame*  read(unsigned size);
       public:
-        int       fd  () const { return _fd; }
-        unsigned  lane() const { return _lane; }
+        int       fd() const { return _fd; }
+        unsigned  usesDataDriver() const { return _usesDataDriver; }
       private:
         enum {BufferWords=8192};
         int                    _fd;
-        unsigned               _lane;
+        bool                   _usesDataDriver;
         unsigned               _readBuffer [BufferWords];
         unsigned               _writeBuffer[BufferWords];
       };


### PR DESCRIPTION
This pull request fixes a bug where the dest field in the pgp frame would be calculated incorrectly for the cards using the datadev driver for all lanes other than lane 0. Basically the module always calculated the dest like it was done for the legacy pgpcard driver: (lane<<2 | vc). The correct way for the datadev driver is (lane<<8 | vc), This gives the same value for lane 0 otherwise its different.

This bug was found when I was makeing an IOC for monitoring the epixM detector environmental data for RIX. The env data from the epixM always comes on lane 6 vc 0 of the kcu. All the previous times this module had been used for a monitoring IOC with the datadev driver, it had always been on lane 0, so it just worked...

The code already had a Destination class to abstract the destination calc, but code was often recalculating this in many places. I tried to clean this up as much as possible. I tested this and is working with both the datadev and legacy pgp drivers for all lanes now.